### PR TITLE
pin pypdf2 dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         "camelot-py[cv]",
-        "pyyaml"
+        "pyyaml",
+        "pypdf2==2.12.1",
     ],
     package_dir={"": "./"},
     packages=find_packages(),


### PR DESCRIPTION
pin pypdf2 dependency to the last 2.x release as newer 3.x releases remove the PDF file parser which nvme-lint relies on.